### PR TITLE
handle non-String onchainMetadata fields

### DIFF
--- a/src/integration-test/java/io/blockfrost/sdk/api/AssetServiceTests.java
+++ b/src/integration-test/java/io/blockfrost/sdk/api/AssetServiceTests.java
@@ -7,7 +7,10 @@ import io.blockfrost.sdk.api.util.OrderEnum;
 import io.blockfrost.sdk.impl.AssetServiceImpl;
 import org.junit.jupiter.api.*;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -72,6 +75,45 @@ public class AssetServiceTests extends TestBase {
 
             Asset asset = assetService.getAsset("07a6604234b758be257f26565445f30169c25c85cf392797bc878de753554d");
             assertThat(asset, is(expectedAsset));
+        }
+
+        @Test
+        public void getAsset_willReturn_assetWithOnchainMetadata() throws APIException {
+            final String filesKey = "files";
+
+            Map<String, String> expectedFiles = new HashMap<>();
+            expectedFiles.put("src", "ipfs://QmaotSicXXa9LzpYKfkt6SWhgTVrRGyBJbTWAgDA1sVBXH");
+            expectedFiles.put("name", "FreeGhost01853");
+            expectedFiles.put("https", "");
+            expectedFiles.put("mediaType", "image/jpeg");
+
+            Map<String, Object> expectedOnchainMetadata = new HashMap<>();
+            expectedOnchainMetadata.put("dna", "00013000");
+            expectedOnchainMetadata.put("back", "College Backpack");
+            expectedOnchainMetadata.put("body", "Blue Shirt");
+            expectedOnchainMetadata.put("eyes", "Normal");
+            expectedOnchainMetadata.put("name", "FreeGhost01853");
+            expectedOnchainMetadata.put(filesKey, Collections.singleton(expectedFiles));
+            expectedOnchainMetadata.put("ghost", "Normal");
+            expectedOnchainMetadata.put("image", "ipfs://QmaotSicXXa9LzpYKfkt6SWhgTVrRGyBJbTWAgDA1sVBXH");
+            expectedOnchainMetadata.put("rarity", "Epic");
+            expectedOnchainMetadata.put("project", "FreeGhost");
+            expectedOnchainMetadata.put("twitter", "twitter.com/freeroam_io");
+            expectedOnchainMetadata.put("website", "FREEROAM TESTING");
+            expectedOnchainMetadata.put("mediaType", "image/jpeg");
+
+            Asset asset = assetService.getAsset("3f5265ef14f89e948fd5b5f55419712ad1f0dd4d75ab26be134441714672656547686f73743031383533");
+            Map<String, Object> onchainMetadata = asset.getOnchainMetadata();
+
+            assertThat(onchainMetadata, notNullValue());
+            expectedOnchainMetadata.entrySet().stream()
+                    .filter(e -> !e.getKey().equals(filesKey))
+                    .forEach(e -> assertThat(onchainMetadata, hasEntry(e.getKey(), e.getValue())));
+
+            assertThat(onchainMetadata.get(filesKey), instanceOf(List.class));
+            @SuppressWarnings("unchecked")
+            List<Map<String, String>> files = (List<Map<String, String>>) onchainMetadata.get(filesKey);
+            expectedFiles.forEach((key, value) -> assertThat(files.get(0), hasEntry(key, value)));
         }
 
         @Test

--- a/src/main/java/io/blockfrost/sdk/api/model/Asset.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/Asset.java
@@ -51,7 +51,7 @@ public class Asset {
      * community discussion around the standard ongoing at
      * https://github.com/cardano-foundation/CIPs/pull/85
      */
-    private Map<String, String> onchainMetadata;
+    private Map<String, Object> onchainMetadata;
     /**
      * Asset metadata
      */


### PR DESCRIPTION
- Changed the type of `onchainMetadata` from `Map<String, String>` to `Map<String, Object>`  to allow for deserialization of complex object values
- Added an IT against a testnet asset that has an onchainMetadata field ("files") which is of type `List<Map<String, String>>`

