### PR TITLE
Add support for scripts endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testCompile("org.junit.jupiter:junit-jupiter-params:5.6.0")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.exparity:hamcrest-date:2.0.0'

--- a/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
+++ b/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
@@ -10,6 +10,7 @@ import io.blockfrost.sdk.api.model.ScriptDatumCbor;
 import io.blockfrost.sdk.api.model.ScriptJson;
 import io.blockfrost.sdk.api.model.ScriptRedeemer;
 import io.blockfrost.sdk.api.model.ScriptType;
+import io.blockfrost.sdk.api.model.ValidationPurpose;
 import io.blockfrost.sdk.api.util.Constants;
 import io.blockfrost.sdk.api.util.OrderEnum;
 import io.blockfrost.sdk.impl.ScriptServiceImpl;
@@ -186,7 +187,7 @@ public class ScriptServiceTests extends TestBase {
             ScriptRedeemer fifthRedeemer = redeemers.get(4);
             assertThat(fifthRedeemer.getTxHash(), is("3543502f973c3daf53febbb63fb1207c0b74293e476a3773b402a6cc17d1b8bf"));
             assertThat(fifthRedeemer.getTxIndex(), is(0));
-            assertThat(fifthRedeemer.getPurpose(), is("spend"));
+            assertThat(fifthRedeemer.getPurpose(), is(ValidationPurpose.spend));
             assertThat(fifthRedeemer.getRedeemerDataHash(), is("fcaa61fb85676101d9e3398a484674e71c45c3fd41b492682f3b0054f4cf3273"));
             assertThat(fifthRedeemer.getDatumHash(), is("fcaa61fb85676101d9e3398a484674e71c45c3fd41b492682f3b0054f4cf3273"));
             assertThat(fifthRedeemer.getUnitMem(), is("1700"));

--- a/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
+++ b/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
@@ -127,7 +127,7 @@ public class ScriptServiceTests extends TestBase {
         public void getScriptJson_willReturn_jsonForTimelockScriptHash() throws APIException {
             ScriptJson scriptJson = scriptService.getScriptJson(TIMELOCK_SCRIPT_HASH);
 
-            Map<String, Object> jsonAsMap = new ObjectMapper().convertValue(scriptJson.getJson(), new TypeReference<>(){});
+            Map<String, Object> jsonAsMap = new ObjectMapper().convertValue(scriptJson.getJson(), new TypeReference<Map<String, Object>>(){});
             assertThat(jsonAsMap.get("type"), is("all"));
             List<Object> scripts = (List)jsonAsMap.get("scripts");
             assertThat(scripts, hasSize(2));

--- a/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
+++ b/src/integration-test/java/io/blockfrost/sdk/api/ScriptServiceTests.java
@@ -1,0 +1,255 @@
+package io.blockfrost.sdk.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.blockfrost.sdk.api.exception.APIException;
+import io.blockfrost.sdk.api.model.Script;
+import io.blockfrost.sdk.api.model.ScriptCbor;
+import io.blockfrost.sdk.api.model.ScriptDatum;
+import io.blockfrost.sdk.api.model.ScriptDatumCbor;
+import io.blockfrost.sdk.api.model.ScriptJson;
+import io.blockfrost.sdk.api.model.ScriptRedeemer;
+import io.blockfrost.sdk.api.model.ScriptType;
+import io.blockfrost.sdk.api.util.Constants;
+import io.blockfrost.sdk.api.util.OrderEnum;
+import io.blockfrost.sdk.impl.ScriptServiceImpl;
+import io.blockfrost.sdk.impl.helper.ValidationHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ScriptServiceTests extends TestBase {
+
+    private static final String PLUTUS_SCRIPT_HASH = "67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656";
+    private static final String TIMELOCK_SCRIPT_HASH = "69b30e43bc5401bb34d0b12bd06cd9b537f33065aa49df7e8652739d";
+
+    private static ScriptService scriptService;
+
+    @BeforeAll
+    public static void setup() {
+        scriptService = new ScriptServiceImpl(Constants.BLOCKFROST_TESTNET_URL, projectId);
+    }
+
+    @Nested
+    @DisplayName("GetScripts Tests")
+    class GetScriptsTests {
+
+        @Test
+        public void getScripts_willReturn_scriptsForCountPageAndAscendingOrder() throws APIException {
+            List<String> expectedScriptHashes = Arrays.asList(
+                    "df22511a7957d47745f5019c2d9f8636cf465afc9e014228c39c708d",
+                    "c2287941693f27466b90eee087b6a0c3a28ecb7151579b554b79e481",
+                    "de1cf53eb63dde7c94c5689bcc6d7f4472da400d6e100fc67460cf84",
+                    "476039a0949cf0b22f6a800f56780184c44533887ca6e821007840c3",
+                    "69b30e43bc5401bb34d0b12bd06cd9b537f33065aa49df7e8652739d"
+            );
+
+            List<Script> scriptList = scriptService.getScripts(5, 1, OrderEnum.asc);
+
+            assertThat(scriptList, hasSize(5));
+            assertThat(scriptList.stream().map(Script::getScriptHash).allMatch(expectedScriptHashes::contains), is(true));
+        }
+
+        @Test
+        public void getScripts_willThrowAPIException_onCountGreaterThan100() {
+            Exception exception = assertThrows(APIException.class, () -> scriptService.getScripts(101, 1, OrderEnum.asc));
+            assertThat(exception.getMessage(), containsString(ValidationHelper.COUNT_VALIDATION_MESSAGE));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("GetScript Tests")
+    class GetScriptTests {
+
+        @Test
+        public void getScript_willReturn_scriptForTimelockScriptHash() throws APIException {
+            Script expectedScript = Script.builder()
+                    .scriptHash(TIMELOCK_SCRIPT_HASH)
+                    .type(ScriptType.timelock)
+                    .serialisedSize(null)
+                    .build();
+
+            Script script = scriptService.getScript(expectedScript.getScriptHash());
+
+            assertThat(script, is(notNullValue()));
+            assertThat(script.getScriptHash(), is(expectedScript.getScriptHash()));
+            assertThat(script.getType(), is(expectedScript.getType()));
+            assertThat(script.getSerialisedSize(), is(expectedScript.getSerialisedSize()));
+        }
+
+        @Test
+        public void getScript_willReturn_scriptForPlutusScriptHash() throws APIException {
+            Script expectedScript = Script.builder()
+                    .scriptHash(PLUTUS_SCRIPT_HASH)
+                    .type(ScriptType.plutusV1)
+                    .serialisedSize(14)
+                    .build();
+
+            Script script = scriptService.getScript(expectedScript.getScriptHash());
+
+            assertThat(script, is(notNullValue()));
+            assertThat(script.getScriptHash(), is(expectedScript.getScriptHash()));
+            assertThat(script.getType(), is(expectedScript.getType()));
+            assertThat(script.getSerialisedSize(), is(expectedScript.getSerialisedSize()));
+        }
+
+        @ParameterizedTest(name = "getScript will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScript_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScript(hash));
+        }
+    }
+
+    @Nested
+    @DisplayName("GetScriptJson Tests")
+    class GetScriptJsonTests {
+
+        @Test
+        public void getScriptJson_willReturn_jsonForTimelockScriptHash() throws APIException {
+            ScriptJson scriptJson = scriptService.getScriptJson(TIMELOCK_SCRIPT_HASH);
+
+            Map<String, Object> jsonAsMap = new ObjectMapper().convertValue(scriptJson.getJson(), new TypeReference<>(){});
+            assertThat(jsonAsMap.get("type"), is("all"));
+            List<Object> scripts = (List)jsonAsMap.get("scripts");
+            assertThat(scripts, hasSize(2));
+        }
+
+        @Test
+        public void getScriptJson_willReturn_nullForPlutusScriptHash() throws APIException {
+            ScriptJson json = scriptService.getScriptJson(PLUTUS_SCRIPT_HASH);
+
+            assertThat(json.getJson().isNull(), is(true));
+        }
+
+        @ParameterizedTest(name = "getScriptJson will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScriptJson_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScriptJson(hash));
+        }
+    }
+
+    @Nested
+    @DisplayName("GetScriptCbor Tests")
+    class GetScriptCborTests {
+
+        @Test
+        public void getScriptCbor_willReturn_cborForPlutusScriptHash() throws APIException {
+            ScriptCbor cbor = scriptService.getScriptCbor(PLUTUS_SCRIPT_HASH);
+
+            assertThat(cbor.getCbor(), is("4e4d01000033222220051200120011"));
+        }
+
+        @Test
+        public void getScriptCbor_willReturn_nullCborForTimelockScriptHash() throws APIException {
+            ScriptCbor cbor = scriptService.getScriptCbor(TIMELOCK_SCRIPT_HASH);
+
+            assertThat(cbor.getCbor(), nullValue());
+        }
+
+        @ParameterizedTest(name = "getScriptCbor will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScriptCbor_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScriptCbor(hash));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("GetScriptRedeemers Tests")
+    class GetScriptRedeemersTests {
+
+        @Test
+        public void getScriptRedeemers_willReturn_redeemersForCountPageAndAscendingOrder() throws APIException {
+            List<ScriptRedeemer> redeemers = scriptService.getScriptRedeemers(PLUTUS_SCRIPT_HASH, 5, 1, OrderEnum.asc);
+
+            assertThat(redeemers, hasSize(5));
+            ScriptRedeemer fifthRedeemer = redeemers.get(4);
+            assertThat(fifthRedeemer.getTxHash(), is("3543502f973c3daf53febbb63fb1207c0b74293e476a3773b402a6cc17d1b8bf"));
+            assertThat(fifthRedeemer.getTxIndex(), is(0));
+            assertThat(fifthRedeemer.getPurpose(), is("spend"));
+            assertThat(fifthRedeemer.getRedeemerDataHash(), is("fcaa61fb85676101d9e3398a484674e71c45c3fd41b492682f3b0054f4cf3273"));
+            assertThat(fifthRedeemer.getDatumHash(), is("fcaa61fb85676101d9e3398a484674e71c45c3fd41b492682f3b0054f4cf3273"));
+            assertThat(fifthRedeemer.getUnitMem(), is("1700"));
+            assertThat(fifthRedeemer.getUnitSteps(), is("476468"));
+            assertThat(fifthRedeemer.getFee(), is("133"));
+        }
+
+        @Test
+        public void getScriptRedeemers_willThrowAPIException_onCountGreaterThan100() {
+            Exception exception = assertThrows(
+                    APIException.class,
+                    () -> scriptService.getScriptRedeemers(PLUTUS_SCRIPT_HASH, 101, 1, OrderEnum.asc)
+            );
+            assertThat(exception.getMessage(), containsString(ValidationHelper.COUNT_VALIDATION_MESSAGE));
+        }
+
+        @ParameterizedTest(name = "getScriptRedeemers will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScriptRedeemers_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScriptRedeemers(hash, 5, 1, OrderEnum.asc));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("GetScriptDatum Tests")
+    class GetScriptDatumTests {
+
+        @Test
+        public void getScriptDatum_willReturn_datumForDatumHash() throws APIException {
+            ScriptDatum datum = scriptService.getScriptDatum("db583ad85881a96c73fbb26ab9e24d1120bb38f45385664bb9c797a2ea8d9a2d");
+
+            assertThat(datum.getJsonValue().get("int").asInt(), is(314));
+        }
+
+        @ParameterizedTest(name = "getScriptDatum will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScriptDatum_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScriptDatum(hash));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("GetScriptDatumCbor Tests")
+    class GetScriptDatumCborTests {
+
+        @Test
+        public void getScriptDatumCbor_willReturn_cborForDatumHash() throws APIException {
+            ScriptDatumCbor cbor = scriptService.getScriptDatumCbor("db583ad85881a96c73fbb26ab9e24d1120bb38f45385664bb9c797a2ea8d9a2d");
+
+            assertThat(cbor.getCbor(), is("19013a"));
+        }
+
+        @ParameterizedTest(name = "getScriptDatumCbor will throw APIException for script hash ''{0}''")
+        @NullSource
+        @ValueSource(strings = {"", " ", "notHex"})
+        public void getScriptDatumCbor_willThrowAPIException_onInvalidScriptHash(String hash) {
+            assertThrows(APIException.class, () -> scriptService.getScriptDatumCbor(hash));
+        }
+
+    }
+
+}

--- a/src/integration-test/java/io/blockfrost/sdk/api/util/HexUtil.java
+++ b/src/integration-test/java/io/blockfrost/sdk/api/util/HexUtil.java
@@ -1,10 +1,11 @@
 package io.blockfrost.sdk.api.util;
 
 public class HexUtil {
+
     public static String encodeHexString(byte[] byteArray) {
         StringBuffer hexStringBuffer = new StringBuffer();
-        for (int i = 0; i < byteArray.length; i++) {
-            hexStringBuffer.append(byteToHex(byteArray[i]));
+        for (byte b : byteArray) {
+            hexStringBuffer.append(byteToHex(b));
         }
         return hexStringBuffer.toString();
     }

--- a/src/main/java/io/blockfrost/sdk/api/ScriptService.java
+++ b/src/main/java/io/blockfrost/sdk/api/ScriptService.java
@@ -1,0 +1,86 @@
+package io.blockfrost.sdk.api;
+
+import io.blockfrost.sdk.api.exception.APIException;
+import io.blockfrost.sdk.api.model.Script;
+import io.blockfrost.sdk.api.model.ScriptCbor;
+import io.blockfrost.sdk.api.model.ScriptDatumCbor;
+import io.blockfrost.sdk.api.model.ScriptDatum;
+import io.blockfrost.sdk.api.model.ScriptJson;
+import io.blockfrost.sdk.api.model.ScriptRedeemer;
+import io.blockfrost.sdk.api.util.OrderEnum;
+
+import java.util.List;
+
+public interface ScriptService {
+
+    /**
+     * Scripts
+     * List of scripts.
+     *
+     * @param count The number of results displayed on one page. (optional, default to 100)
+     * @param page  The page number for listing the results. (optional, default to 1)
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself.
+     *              By default, we return the oldest first, the newest last. (optional, default to "asc")
+     * @return List&lt;Script&gt;
+     */
+    List<Script> getScripts(int count, int page, OrderEnum order) throws APIException;
+
+    /**
+     * Specific script
+     * Information about a specific script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return Script
+     */
+    Script getScript(String scriptHash) throws APIException;
+
+    /**
+     * Script JSON
+     * JSON representation of a timelock script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return ScriptJson
+     */
+    ScriptJson getScriptJson(String scriptHash) throws APIException;
+
+    /**
+     * Script CBOR
+     * CBOR representation of a plutus script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return ScriptCbor
+     */
+    ScriptCbor getScriptCbor(String scriptHash) throws APIException;
+
+    /**
+     * Redeemers of a specific script
+     * List of redeemers of a specific script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @param count The number of results displayed on one page. (optional, default to 100)
+     * @param page  The page number for listing the results. (optional, default to 1)
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself.
+     *              By default, we return the oldest first, the newest last. (optional, default to "asc")
+     * @return List&lt;ScriptRedeemer&gt;
+     */
+    List<ScriptRedeemer> getScriptRedeemers(String scriptHash, int count, int page, OrderEnum order) throws APIException;
+
+    /**
+     * Datum value
+     * Query JSON value of a datum by its hash.
+     *
+     * @param datumHash Hash of the datum. (required)
+     * @return ScriptDatum
+     */
+    ScriptDatum getScriptDatum(String datumHash) throws APIException;
+
+
+    /**
+     * Datum CBOR value
+     * Query CBOR serialised datum by its hash.
+     *
+     * @param datumHash Hash of the datum. (required)
+     * @return ScriptDatumCbor
+     */
+    ScriptDatumCbor getScriptDatumCbor(String datumHash) throws APIException;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/Script.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/Script.java
@@ -1,0 +1,29 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Script
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class Script {
+    private String scriptHash;
+    private ScriptType type;
+    private Integer serialisedSize;
+}
+

--- a/src/main/java/io/blockfrost/sdk/api/model/Script.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/Script.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * Script
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptCbor.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptCbor.java
@@ -1,0 +1,26 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * ScriptCbor
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ScriptCbor {
+    private String cbor;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptCbor.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptCbor.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * ScriptCbor
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptDatum.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptDatum.java
@@ -1,0 +1,27 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * ScriptDatum
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ScriptDatum {
+    private JsonNode JsonValue;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptDatum.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptDatum.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptDatumCbor.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptDatumCbor.java
@@ -1,0 +1,26 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * ScriptDatumCbor
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ScriptDatumCbor {
+    private String cbor;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptDatumCbor.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptDatumCbor.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * ScriptDatumCbor
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptJson.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptJson.java
@@ -1,0 +1,27 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * ScriptJson
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ScriptJson {
+    private JsonNode json;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptJson.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptJson.java
@@ -6,15 +6,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * ScriptJson
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 public class ScriptRedeemer {
     private String txHash;
     private Integer txIndex;
-    private String purpose;
+    private ValidationPurpose purpose;
     private String redeemerDataHash;
     private String datumHash;
     private String unitMem;

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
@@ -1,0 +1,33 @@
+package io.blockfrost.sdk.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * ScriptRedeemer
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ScriptRedeemer {
+    private String txHash;
+    private Integer txIndex;
+    private String purpose;
+    private String redeemerDataHash;
+    private String datumHash;
+    private String unitMem;
+    private String unitSteps;
+    private String fee;
+}

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptRedeemer.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
  * ScriptRedeemer
  */
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/io/blockfrost/sdk/api/model/ScriptType.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ScriptType.java
@@ -1,0 +1,8 @@
+package io.blockfrost.sdk.api.model;
+
+public enum ScriptType {
+    timelock,
+    plutusV1,
+    plutusV2
+}
+

--- a/src/main/java/io/blockfrost/sdk/api/model/ValidationPurpose.java
+++ b/src/main/java/io/blockfrost/sdk/api/model/ValidationPurpose.java
@@ -1,0 +1,9 @@
+package io.blockfrost.sdk.api.model;
+
+public enum ValidationPurpose {
+    spend,
+    mint,
+    cert,
+    reward
+}
+

--- a/src/main/java/io/blockfrost/sdk/impl/ScriptServiceImpl.java
+++ b/src/main/java/io/blockfrost/sdk/impl/ScriptServiceImpl.java
@@ -1,0 +1,142 @@
+package io.blockfrost.sdk.impl;
+
+import io.blockfrost.sdk.api.ScriptService;
+import io.blockfrost.sdk.api.exception.APIException;
+import io.blockfrost.sdk.api.model.Script;
+import io.blockfrost.sdk.api.model.ScriptCbor;
+import io.blockfrost.sdk.api.model.ScriptDatumCbor;
+import io.blockfrost.sdk.api.model.ScriptDatum;
+import io.blockfrost.sdk.api.model.ScriptJson;
+import io.blockfrost.sdk.api.model.ScriptRedeemer;
+import io.blockfrost.sdk.api.util.OrderEnum;
+import io.blockfrost.sdk.impl.helper.ValidationHelper;
+import io.blockfrost.sdk.impl.retrofit.ScriptsApi;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class ScriptServiceImpl extends BaseService implements ScriptService {
+
+    ScriptsApi scriptsApi;
+
+    public ScriptServiceImpl(String baseUrl, String projectId) {
+        super(baseUrl, projectId);
+        scriptsApi = getRetrofit().create(ScriptsApi.class);
+    }
+
+    @Override
+    public List<Script> getScripts(int count, int page, OrderEnum order) throws APIException {
+        ValidationHelper.validateCount(count);
+
+        Call<List<Script>> call = scriptsApi.scriptsGet(getProjectId(), count, page, order.name());
+
+        try {
+            Response<List<Script>> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching scripts", exp);
+        }
+    }
+
+    @Override
+    public Script getScript(String scriptHash) throws APIException {
+        validateHash(scriptHash);
+
+        Call<Script> call = scriptsApi.scriptsScriptHashGet(getProjectId(), scriptHash);
+
+        try {
+            Response<Script> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script for hash: " + scriptHash, exp);
+        }
+    }
+
+    @Override
+    public ScriptJson getScriptJson(String scriptHash) throws APIException {
+        validateHash(scriptHash);
+
+        Call<ScriptJson> call = scriptsApi.scriptsScriptHashJsonGet(getProjectId(), scriptHash);
+
+        try {
+            Response<ScriptJson> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script JSON representation for hash: " + scriptHash, exp);
+        }
+    }
+
+    @Override
+    public ScriptCbor getScriptCbor(String scriptHash) throws APIException {
+        validateHash(scriptHash);
+
+        Call<ScriptCbor> call = scriptsApi.scriptsScriptHashCborGet(getProjectId(), scriptHash);
+
+        try {
+            Response<ScriptCbor> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script CBOR representation for hash: " + scriptHash, exp);
+        }
+    }
+
+    @Override
+    public List<ScriptRedeemer> getScriptRedeemers(String scriptHash, int count, int page, OrderEnum order) throws APIException {
+        ValidationHelper.validateCount(count);
+        validateHash(scriptHash);
+
+        Call<List<ScriptRedeemer>> call = scriptsApi.scriptsScriptHashRedeemersGet(getProjectId(), scriptHash, count, page, order.name());
+
+        try {
+            Response<List<ScriptRedeemer>> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script redeemers for hash: " + scriptHash, exp);
+        }
+    }
+
+    @Override
+    public ScriptDatum getScriptDatum(String datumHash) throws APIException {
+        validateHash(datumHash);
+
+        Call<ScriptDatum> call = scriptsApi.scriptsDatumDatumHashGet(getProjectId(), datumHash);
+
+        try {
+            Response<ScriptDatum> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script datum for hash: " + datumHash, exp);
+        }
+    }
+
+    @Override
+    public ScriptDatumCbor getScriptDatumCbor(String datumHash) throws APIException {
+        validateHash(datumHash);
+
+        Call<ScriptDatumCbor> call = scriptsApi.scriptsDatumDatumHashCborGet(getProjectId(), datumHash);
+
+        try {
+            Response<ScriptDatumCbor> response = call.execute();
+            return processResponse(response);
+        } catch (IOException exp) {
+            throw new APIException("Exception while fetching script datum CBOR representation for hash: " + datumHash, exp);
+        }
+    }
+
+    private static void validateHash(String hash) throws APIException {
+        if (hash == null || hash.trim().isEmpty()) {
+            throw new APIException("Hash cannot be null or empty");
+        }
+
+        if(!isHexadecimal(hash)) {
+            throw new APIException("Hash must be an hexadecimal value");
+        }
+    }
+
+    private static boolean isHexadecimal(String input) {
+        return Pattern.compile("\\p{XDigit}+").matcher(input).matches();
+    }
+}

--- a/src/main/java/io/blockfrost/sdk/impl/ScriptServiceImpl.java
+++ b/src/main/java/io/blockfrost/sdk/impl/ScriptServiceImpl.java
@@ -16,7 +16,6 @@ import retrofit2.Response;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public class ScriptServiceImpl extends BaseService implements ScriptService {
 
@@ -43,7 +42,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
 
     @Override
     public Script getScript(String scriptHash) throws APIException {
-        validateHash(scriptHash);
+        ValidationHelper.validateHexadecimalHash(scriptHash);
 
         Call<Script> call = scriptsApi.scriptsScriptHashGet(getProjectId(), scriptHash);
 
@@ -57,7 +56,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
 
     @Override
     public ScriptJson getScriptJson(String scriptHash) throws APIException {
-        validateHash(scriptHash);
+        ValidationHelper.validateHexadecimalHash(scriptHash);
 
         Call<ScriptJson> call = scriptsApi.scriptsScriptHashJsonGet(getProjectId(), scriptHash);
 
@@ -71,7 +70,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
 
     @Override
     public ScriptCbor getScriptCbor(String scriptHash) throws APIException {
-        validateHash(scriptHash);
+        ValidationHelper.validateHexadecimalHash(scriptHash);
 
         Call<ScriptCbor> call = scriptsApi.scriptsScriptHashCborGet(getProjectId(), scriptHash);
 
@@ -86,7 +85,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
     @Override
     public List<ScriptRedeemer> getScriptRedeemers(String scriptHash, int count, int page, OrderEnum order) throws APIException {
         ValidationHelper.validateCount(count);
-        validateHash(scriptHash);
+        ValidationHelper.validateHexadecimalHash(scriptHash);
 
         Call<List<ScriptRedeemer>> call = scriptsApi.scriptsScriptHashRedeemersGet(getProjectId(), scriptHash, count, page, order.name());
 
@@ -100,7 +99,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
 
     @Override
     public ScriptDatum getScriptDatum(String datumHash) throws APIException {
-        validateHash(datumHash);
+        ValidationHelper.validateHexadecimalHash(datumHash);
 
         Call<ScriptDatum> call = scriptsApi.scriptsDatumDatumHashGet(getProjectId(), datumHash);
 
@@ -114,7 +113,7 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
 
     @Override
     public ScriptDatumCbor getScriptDatumCbor(String datumHash) throws APIException {
-        validateHash(datumHash);
+        ValidationHelper.validateHexadecimalHash(datumHash);
 
         Call<ScriptDatumCbor> call = scriptsApi.scriptsDatumDatumHashCborGet(getProjectId(), datumHash);
 
@@ -126,17 +125,4 @@ public class ScriptServiceImpl extends BaseService implements ScriptService {
         }
     }
 
-    private static void validateHash(String hash) throws APIException {
-        if (hash == null || hash.trim().isEmpty()) {
-            throw new APIException("Hash cannot be null or empty");
-        }
-
-        if(!isHexadecimal(hash)) {
-            throw new APIException("Hash must be an hexadecimal value");
-        }
-    }
-
-    private static boolean isHexadecimal(String input) {
-        return Pattern.compile("\\p{XDigit}+").matcher(input).matches();
-    }
 }

--- a/src/main/java/io/blockfrost/sdk/impl/helper/ValidationHelper.java
+++ b/src/main/java/io/blockfrost/sdk/impl/helper/ValidationHelper.java
@@ -2,14 +2,34 @@ package io.blockfrost.sdk.impl.helper;
 
 import io.blockfrost.sdk.api.exception.APIException;
 
+import java.util.regex.Pattern;
+
 public class ValidationHelper {
 
     public static final String COUNT_VALIDATION_MESSAGE = "Count should be <= 100";
+    public static final String BLANK_HASH_VALIDATION_MESSAGE = "Hash cannot be null or empty";
+    public static final String HEXADECIMAL_HASH_VALIDATION_MESSAGE = "Hash must be an hexadecimal value";
+
+    private static final String HEXADECIMAL_PATTERN = "\\p{XDigit}+";
 
     public static void validateCount(int count) throws APIException {
         if (count > 100) {
             throw new APIException(COUNT_VALIDATION_MESSAGE);
         }
+    }
+
+    public static void validateHexadecimalHash(String hash) throws APIException {
+        if (hash == null || hash.trim().isEmpty()) {
+            throw new APIException(BLANK_HASH_VALIDATION_MESSAGE);
+        }
+
+        if(!isHexadecimal(hash)) {
+            throw new APIException(HEXADECIMAL_HASH_VALIDATION_MESSAGE);
+        }
+    }
+
+    private static boolean isHexadecimal(String input) {
+        return Pattern.compile(HEXADECIMAL_PATTERN).matcher(input).matches();
     }
 
 }

--- a/src/main/java/io/blockfrost/sdk/impl/retrofit/ScriptsApi.java
+++ b/src/main/java/io/blockfrost/sdk/impl/retrofit/ScriptsApi.java
@@ -1,0 +1,123 @@
+package io.blockfrost.sdk.impl.retrofit;
+
+import io.blockfrost.sdk.api.model.Script;
+import io.blockfrost.sdk.api.model.ScriptCbor;
+import io.blockfrost.sdk.api.model.ScriptDatumCbor;
+import io.blockfrost.sdk.api.model.ScriptDatum;
+import io.blockfrost.sdk.api.model.ScriptJson;
+import io.blockfrost.sdk.api.model.ScriptRedeemer;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+import java.util.List;
+
+public interface ScriptsApi {
+
+    /**
+     * Scripts
+     * List of scripts.
+     *
+     * @param count The number of results displayed on one page. (optional, default to 100)
+     * @param page  The page number for listing the results. (optional, default to 1)
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself.
+     *              By default, we return the oldest first, the newest last. (optional, default to "asc")
+     * @return Call&lt;List&lt;Script&gt;&gt;
+     */
+    @GET("scripts")
+    Call<List<Script>> scriptsGet(
+            @Header("project_id") String projectId,
+            @Query("count") Integer count,
+            @Query("page") Integer page,
+            @Query("order") String order
+    );
+
+    /**
+     * Specific script
+     * Information about a specific script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return Call&lt;Script&gt;
+     */
+    @GET("scripts/{script_hash}")
+    Call<Script> scriptsScriptHashGet(
+            @Header("project_id") String projectId,
+            @Path("script_hash") String scriptHash
+    );
+
+    /**
+     * Script JSON
+     * JSON representation of a timelock script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return Call&lt;ScriptJson&gt;
+     */
+    @GET("scripts/{script_hash}/json")
+    Call<ScriptJson> scriptsScriptHashJsonGet(
+            @Header("project_id") String projectId,
+            @Path("script_hash") String scriptHash
+    );
+
+    /**
+     * Script CBOR
+     * CBOR representation of a plutus script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @return Call&lt;ScriptCbor&gt;
+     */
+    @GET("scripts/{script_hash}/cbor")
+    Call<ScriptCbor> scriptsScriptHashCborGet(
+            @Header("project_id") String projectId,
+            @Path("script_hash") String scriptHash
+    );
+
+    /**
+     * Redeemers of a specific script
+     * List of redeemers of a specific script.
+     *
+     * @param scriptHash Hash of the script. (required)
+     * @param count The number of results displayed on one page. (optional, default to 100)
+     * @param page  The page number for listing the results. (optional, default to 1)
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself.
+     *              By default, we return the oldest first, the newest last. (optional, default to "asc")
+     * @return Call&lt;List&lt;ScriptRedeemer&gt;&gt;
+     */
+    @GET("scripts/{script_hash}/redeemers")
+    Call<List<ScriptRedeemer>> scriptsScriptHashRedeemersGet(
+            @Header("project_id") String projectId,
+            @Path("script_hash") String scriptHash,
+            @Query("count") Integer count,
+            @Query("page") Integer page,
+            @Query("order") String order
+    );
+
+    /**
+     * Datum value
+     * Query JSON value of a datum by its hash
+     *
+     * @param datumHash Hash of the datum. (required)
+     * @return Call&lt;ScriptDatum&gt;
+     */
+    @GET("scripts/datum/{datum_hash}")
+    Call<ScriptDatum> scriptsDatumDatumHashGet(
+            @Header("project_id") String projectId,
+            @Path("datum_hash") String datumHash
+    );
+
+
+    /**
+     * Datum CBOR value
+     * Query CBOR serialised datum by its hash
+     *
+     * @param datumHash Hash of the datum. (required)
+     * @return Call&lt;ScriptDatumCbor&gt;
+     */
+    @GET("scripts/datum/{datum_hash}/cbor")
+    Call<ScriptDatumCbor> scriptsDatumDatumHashCborGet(
+            @Header("project_id") String projectId,
+            @Path("datum_hash") String datumHash
+    );
+
+}


### PR DESCRIPTION
- Add `junit-jupiter-params` to write parameterized tests
- Add support for script endpoints as described [here](https://docs.blockfrost.io/#tag/Cardano-Scripts)
- Add tests with `timelock` and `plutusV1` scripts I found around. I can change them if you have specific script hashes you want me to use instead. I could also add tests for a `plutusV2` scripts if you have a hash. 

